### PR TITLE
Update Dependency `dotenv` from 10.x.x to 16.x.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1441,9 +1441,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jest": "27.5.0"
   },
   "dependencies": {
-    "dotenv": "10.0.0",
+    "dotenv": "16.0.0",
     "express": "4.17.1"
   }
 }


### PR DESCRIPTION
## Description

This PR performs a major dependency update to the `dotenv` dependency.

Previously this dependency was on version `10.x.x`, and after this PR it will be on version `16.x.x`